### PR TITLE
Fixed regex error in backend validation

### DIFF
--- a/backend/buildeR.Common/FluentValidators/Shared/EmailRule.cs
+++ b/backend/buildeR.Common/FluentValidators/Shared/EmailRule.cs
@@ -1,16 +1,30 @@
-using System.Text.RegularExpressions;
+using System;
+using System.Net.Mail;
 using FluentValidation;
 
 namespace buildeR.Common.FluentValidators.Shared
 {
     public static class EmailRule
     {
-        private static readonly Regex HasDigit = new Regex(@"\d");
-
         public static IRuleBuilderOptions<T, string> Email<T>(this IRuleBuilder<T, string> rule)
         {
+            static bool ValidEmail(string input)
+            {
+                try
+                {
+                    var m = new MailAddress(input);
+
+                    return true;
+                }
+                catch (FormatException)
+                {
+                    return false;
+                }
+            }
+
             return rule
-                .Must(input => !HasDigit.IsMatch(input));
+                .Must(ValidEmail)
+                .NoNonLatinLetters();
         }
     }
 }

--- a/backend/buildeR.Common/FluentValidators/Shared/EmailRule.cs
+++ b/backend/buildeR.Common/FluentValidators/Shared/EmailRule.cs
@@ -1,0 +1,16 @@
+using System.Text.RegularExpressions;
+using FluentValidation;
+
+namespace buildeR.Common.FluentValidators.Shared
+{
+    public static class EmailRule
+    {
+        private static readonly Regex HasDigit = new Regex(@"\d");
+
+        public static IRuleBuilderOptions<T, string> Email<T>(this IRuleBuilder<T, string> rule)
+        {
+            return rule
+                .Must(input => !HasDigit.IsMatch(input));
+        }
+    }
+}

--- a/backend/buildeR.Common/FluentValidators/Shared/SpecialCharactersRules.cs
+++ b/backend/buildeR.Common/FluentValidators/Shared/SpecialCharactersRules.cs
@@ -7,7 +7,16 @@ namespace buildeR.Common.FluentValidators.Shared
 {
     public static class SpecialCharactersRules
     {
-        private static string SpecialCharsExceptRegExr(params char[] chars) => $@"[^a-zA-Z0-9\{string.Join(@"\", chars)}]";
+        private static Regex SpecialCharsExceptRegExr(params char[] chars)
+        {
+            if (chars.Contains('-'))
+            {
+                chars = chars.Except(new []{'-'}).ToArray();
+                return new Regex($@"[^a-zA-Z0-9-{string.Concat(chars.Select(ch => Regex.Escape(ch.ToString())))}]");
+            }
+            return new Regex($@"[^a-zA-Z0-9{string.Concat(chars.Select(ch => Regex.Escape(ch.ToString())))}]");
+        }
+
         private static readonly Regex HyphenOnEdges = new Regex(@"^-|-$");
         private static readonly Regex SpacesOnEdges = new Regex(@"^ | $");
         private static readonly Regex DotsOnEdges = new Regex(@"^\.|\.$");
@@ -22,7 +31,7 @@ namespace buildeR.Common.FluentValidators.Shared
         public static IRuleBuilderOptions<T, string> NoSpecialCharsExcept<T>(this IRuleBuilder<T, string> rule, params char[] chars)
         {
             return rule
-                .Must(input => !new Regex(SpecialCharsExceptRegExr(chars)).IsMatch(input));
+                .Must(input => !SpecialCharsExceptRegExr(chars).IsMatch(input));
         }
 
         public static IRuleBuilderOptions<T, string> NoHyphenOnEdges<T>(this IRuleBuilder<T, string> rule)

--- a/backend/buildeR.Common/FluentValidators/User/NewUserDtoValidator.cs
+++ b/backend/buildeR.Common/FluentValidators/User/NewUserDtoValidator.cs
@@ -1,4 +1,5 @@
 using buildeR.Common.DTO.User;
+using buildeR.Common.FluentValidators.Shared;
 using FluentValidation;
 
 namespace buildeR.Common.FluentValidators.User
@@ -10,7 +11,7 @@ namespace buildeR.Common.FluentValidators.User
             RuleFor(u => u.Username).Username();
             RuleFor(u => u.LastName).LastName();
             RuleFor(u => u.FirstName).FirstName();
-            RuleFor(u => u.Email).CustomEmail();
+            RuleFor(u => u.Email).Email();
             RuleFor(u => u.Bio).Bio();
         }
     }

--- a/backend/buildeR.Common/FluentValidators/User/UserDtoValidator.cs
+++ b/backend/buildeR.Common/FluentValidators/User/UserDtoValidator.cs
@@ -1,6 +1,6 @@
 using buildeR.Common.DTO.User;
+using buildeR.Common.FluentValidators.Shared;
 using FluentValidation;
-using FluentValidation.Validators;
 
 namespace buildeR.Common.FluentValidators.User
 {
@@ -11,7 +11,7 @@ namespace buildeR.Common.FluentValidators.User
             RuleFor(u => u.Username).Username();
             RuleFor(u => u.LastName).LastName();
             RuleFor(u => u.FirstName).FirstName();
-            RuleFor(u => u.Email).CustomEmail();
+            RuleFor(u => u.Email).Email();
             RuleFor(u => u.Bio).Bio();
         }
     }

--- a/backend/buildeR.Common/FluentValidators/User/UserSharedRules.cs
+++ b/backend/buildeR.Common/FluentValidators/User/UserSharedRules.cs
@@ -2,8 +2,6 @@ using System;
 using System.Net.Mail;
 using buildeR.Common.FluentValidators.Shared;
 using FluentValidation;
-using SendGrid.Helpers.Mail;
-using static buildeR.Common.FluentValidators.Shared.SpecialCharactersRules;
 
 namespace buildeR.Common.FluentValidators.User
 {
@@ -43,7 +41,7 @@ namespace buildeR.Common.FluentValidators.User
             {
                 try
                 {
-                    var m = new EmailAddress(input);
+                    var m = new MailAddress(input);
 
                     return true;
                 }

--- a/backend/buildeR.Common/FluentValidators/User/UserSharedRules.cs
+++ b/backend/buildeR.Common/FluentValidators/User/UserSharedRules.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Net.Mail;
 using buildeR.Common.FluentValidators.Shared;
 using FluentValidation;
 
@@ -35,27 +33,6 @@ namespace buildeR.Common.FluentValidators.User
                 .FirstName();
         }
 
-        public static IRuleBuilderOptions<T, string> CustomEmail<T>(this IRuleBuilder<T, string> rule)
-        {
-            static bool ValidEmail(string input)
-            {
-                try
-                {
-                    var m = new MailAddress(input);
-
-                    return true;
-                }
-                catch (FormatException)
-                {
-                    return false;
-                }
-            }
-
-            return rule
-                .Must(ValidEmail)
-                .NoNonLatinLetters();
-        }
-        
         public static IRuleBuilderOptions<T, string> Bio<T>(this IRuleBuilder<T, string> rule)
         {
             return rule


### PR DESCRIPTION
The exception was thrown no matter what: 

System.Text.RegularExpressions.RegexParseException: 
Invalid pattern '[^a-zA-Z0-9\ \-\.\_]' at offset 19. Unrecognized escape sequence \\_.